### PR TITLE
Detect when ready to cast again

### DIFF
--- a/run.py
+++ b/run.py
@@ -214,7 +214,7 @@ def main():
                     print('release')
                     release += 1
 
-                    if release > 10:
+                    if release > 15 or pyautogui.locateOnScreen('f3.png', confidence=0.8) != None:
                         print('Grats on the fish! (I hope) -- Restarting loop')
                         pydirectinput.keyUp('altleft')
                         fishcaught += 1


### PR DESCRIPTION
Checking for the F3 image after catch allows it to wait longer for when you get a cutscene like rare pull but also know quickly when you're ready to recast on common fish. 